### PR TITLE
Remove websockets dependency in favor of wsproto

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ cd tts-reader/backend
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn app:app --reload
-# For production with uvloop and wsproto:
+uvicorn app:app --reload --ws wsproto
+# For production with uvloop:
 uvicorn app:app --host 0.0.0.0 --port 8000 --loop uvloop --http h11 --ws wsproto
 ```
 

--- a/docs/BUILD_BRIEF.md
+++ b/docs/BUILD_BRIEF.md
@@ -32,7 +32,7 @@ Target platforms for MVP: **Web** (React) + **Python backend (FastAPI)**. Aim fo
 
 ## Tech Stack (pick these)
 
-* **Backend**: Python 3.11, **FastAPI**, **uvicorn**, **pydantic**, **websockets**.
+* **Backend**: Python 3.11, **FastAPI**, **uvicorn**, **pydantic**, **wsproto**.
 * **Parsing**: **PyMuPDF (fitz)** primary, **pdfminer.six** secondary reconciliation, optional **PaddleOCR** for scans.
 * **Layout**: **layoutparser** + **Detectron2** (provide CPU fallback heuristics if model missing).
 * **NLP**: **spaCy** (en\_core\_web\_sm), **wordfreq** (hyphen fix), regex for normalization.

--- a/docs/ISSUES_AND_FIXES.md
+++ b/docs/ISSUES_AND_FIXES.md
@@ -6,5 +6,6 @@
 - `backend/requirements.txt` lacked a trailing newline which could confuse tooling. Added the newline.
 - Switched the runtime stack to pinned `fastapi`, `uvicorn`, `wsproto`, and `uvloop` versions, replacing the legacy `websockets` dep.
   Added a version check script and README guidance on running Uvicorn with `uvloop` and `wsproto`.
+- Removed the leftover `websockets` requirement and updated the quick start to default to `wsproto` to avoid `websockets.legacy` errors.
 
 These fixes improve runtime reliability and code cleanliness.

--- a/tts-reader/backend/requirements.txt
+++ b/tts-reader/backend/requirements.txt
@@ -1,6 +1,5 @@
 fastapi>=0.110,<1.0
 uvicorn[standard]>=0.30,<0.31
-websockets<12.0
 wsproto>=1.2,<1.3
 uvloop>=0.21.0
 python-multipart


### PR DESCRIPTION
## Summary
- drop legacy `websockets` requirement in favor of `wsproto`
- default uvicorn commands to `--ws wsproto`
- update build brief and changelog to reflect wsproto stack

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689be6232d188332aca81a9e3c1b0dd7