### PR TITLE
feat: add Poopify Chrome extension MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ build/
 
 # Lock files
 **/package-lock.json
+
+# Chrome extension build artifacts
+clients/extension/**/*.js
+clients/extension/icons/

--- a/clients/extension/background.ts
+++ b/clients/extension/background.ts
@@ -1,0 +1,107 @@
+const CONTEXT_MENU_ID = 'poopify-read-selection';
+
+interface Settings {
+  rate: number;
+  voice: string;
+}
+
+let settings: Settings = { rate: 1.0, voice: 'default' };
+let currentWs: WebSocket | null = null;
+let currentTabId: number | null = null;
+let receivedAudio = false;
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({ id: CONTEXT_MENU_ID, title: 'Read selection with Poopify', contexts: ['selection'] });
+  chrome.storage.sync.get(settings).then((s: any) => { settings = Object.assign(settings, s); });
+});
+
+chrome.runtime.onMessage.addListener((msg: any, sender: any) => {
+  if (msg.type === 'play-text') {
+    (async () => {
+      const text: string = msg.text || '';
+      if (!text.trim()) return;
+      let tabId = msg.tabId as number | undefined;
+      if (!tabId) {
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        tabId = tab.id;
+      }
+      startTts(text, tabId!, msg.playInTab !== false);
+    })();
+  } else if (msg.type === 'stop') {
+    stopTts();
+  } else if (msg.type === 'set-settings') {
+    settings.rate = msg.rate ?? settings.rate;
+    settings.voice = msg.voice ?? settings.voice;
+    chrome.storage.sync.set(settings);
+  }
+});
+
+chrome.contextMenus.onClicked.addListener((info: any, tab: any) => {
+  if (info.menuItemId === CONTEXT_MENU_ID && tab?.id) {
+    chrome.tabs.sendMessage(tab.id, { type: 'get-selection' }, (response: any) => {
+      const text = response?.text || '';
+      if (text.trim()) startTts(text, tab.id!, true);
+    });
+  }
+});
+
+function startTts(text: string, tabId: number, useContent: boolean) {
+  stopTts();
+  currentTabId = tabId;
+  try {
+    const ws = new WebSocket('ws://127.0.0.1:8000/api/stream');
+    currentWs = ws;
+    receivedAudio = false;
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ text, rate: settings.rate, voice: settings.voice }));
+      if (useContent) {
+        chrome.tabs.sendMessage(tabId, { type: 'tts-start', engine: 'daemon' });
+      }
+    };
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        if (msg.type === 'audio') {
+          receivedAudio = true;
+          if (useContent) {
+            chrome.tabs.sendMessage(tabId, {
+              type: 'tts-audio',
+              pcm16: msg.pcm16_base64,
+              sampleRate: msg.sample_rate || 22050,
+              rate: settings.rate,
+            });
+          }
+        }
+      } catch (e) {
+        // ignore non-JSON
+      }
+    };
+    ws.onerror = () => {
+      ws.close();
+    };
+    ws.onclose = () => {
+      if (!receivedAudio) {
+        fallbackWebSpeech(text, tabId, useContent);
+      }
+    };
+  } catch (e) {
+    fallbackWebSpeech(text, tabId, useContent);
+  }
+}
+
+function stopTts() {
+  if (currentWs) {
+    currentWs.close();
+    currentWs = null;
+  }
+  if (currentTabId != null) {
+    chrome.tabs.sendMessage(currentTabId, { type: 'tts-stop' });
+  }
+  currentTabId = null;
+}
+
+function fallbackWebSpeech(text: string, tabId: number, useContent: boolean) {
+  if (useContent) {
+    chrome.tabs.sendMessage(tabId, { type: 'speak-webspeech', text, rate: settings.rate });
+  }
+}

--- a/clients/extension/content.ts
+++ b/clients/extension/content.ts
@@ -1,0 +1,21 @@
+import { AudioPlayer } from './utils/audio.js';
+
+const player = new AudioPlayer();
+
+chrome.runtime.onMessage.addListener((msg: any, sender: any, sendResponse: any) => {
+  if (msg.type === 'get-selection') {
+    const text = window.getSelection()?.toString() || '';
+    sendResponse({ text });
+  } else if (msg.type === 'tts-audio') {
+    player.setRate(msg.rate || 1.0);
+    player.enqueue(msg.pcm16, msg.sampleRate || 22050);
+  } else if (msg.type === 'tts-stop') {
+    player.stop();
+  } else if (msg.type === 'speak-webspeech') {
+    player.stop();
+    const u = new SpeechSynthesisUtterance(msg.text);
+    u.rate = msg.rate || 1.0;
+    speechSynthesis.speak(u);
+  }
+  return true;
+});

--- a/clients/extension/global.d.ts
+++ b/clients/extension/global.d.ts
@@ -1,0 +1,1 @@
+declare const chrome: any;

--- a/clients/extension/manifest.json
+++ b/clients/extension/manifest.json
@@ -1,0 +1,30 @@
+{
+  "manifest_version": 3,
+  "name": "Poopify TTS",
+  "version": "0.1.0",
+  "description": "Poopify text-to-speech extension",
+  "permissions": ["activeTab", "contextMenus", "storage", "scripting"],
+  "host_permissions": ["http://127.0.0.1/*", "ws://127.0.0.1/*"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Poopify"
+  },
+  "minimum_chrome_version": "114",
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "type": "module",
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/clients/extension/popup.html
+++ b/clients/extension/popup.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { font-family: sans-serif; width: 300px; margin: 0.5em; }
+    textarea { width: 100%; height: 120px; }
+    label { display: block; margin-top: 0.5em; }
+  </style>
+</head>
+<body>
+  <textarea id="text"></textarea>
+  <label>Rate: <input type="range" min="0.8" max="2.0" step="0.1" id="rate"><span id="rateLabel"></span></label>
+  <label>Voice: <select id="voice"><option value="default">default</option></select></label>
+  <label><input type="checkbox" id="playInTab" checked> Play in this tab</label>
+  <div style="margin-top:0.5em;">
+    <button id="play">Play</button>
+    <button id="stop">Stop</button>
+  </div>
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/clients/extension/popup.ts
+++ b/clients/extension/popup.ts
@@ -1,0 +1,31 @@
+const textEl = document.getElementById('text') as HTMLTextAreaElement;
+const rateEl = document.getElementById('rate') as HTMLInputElement;
+const rateLabel = document.getElementById('rateLabel') as HTMLElement;
+const voiceEl = document.getElementById('voice') as HTMLSelectElement;
+const playInTabEl = document.getElementById('playInTab') as HTMLInputElement;
+const playBtn = document.getElementById('play') as HTMLButtonElement;
+const stopBtn = document.getElementById('stop') as HTMLButtonElement;
+
+chrome.storage.sync.get({ rate: 1.0, voice: 'default' }).then((s: any) => {
+  rateEl.value = String(s.rate);
+  rateLabel.textContent = s.rate.toFixed(1);
+  voiceEl.value = s.voice;
+});
+
+rateEl.addEventListener('input', () => {
+  rateLabel.textContent = parseFloat(rateEl.value).toFixed(1);
+  chrome.runtime.sendMessage({ type: 'set-settings', rate: parseFloat(rateEl.value), voice: voiceEl.value });
+});
+
+voiceEl.addEventListener('change', () => {
+  chrome.runtime.sendMessage({ type: 'set-settings', rate: parseFloat(rateEl.value), voice: voiceEl.value });
+});
+
+playBtn.addEventListener('click', () => {
+  const text = textEl.value.trim();
+  chrome.runtime.sendMessage({ type: 'play-text', text, playInTab: playInTabEl.checked });
+});
+
+stopBtn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'stop' });
+});

--- a/clients/extension/tsconfig.json
+++ b/clients/extension/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["*.ts", "utils/*.ts"]
+}

--- a/clients/extension/utils/audio.ts
+++ b/clients/extension/utils/audio.ts
@@ -1,0 +1,66 @@
+export function decodePcm16(pcm16Base64: string): Float32Array {
+  const binary = atob(pcm16Base64);
+  const len = binary.length / 2;
+  const out = new Float32Array(len);
+  for (let i = 0; i < len; i++) {
+    const lo = binary.charCodeAt(i * 2);
+    const hi = binary.charCodeAt(i * 2 + 1);
+    let val = (hi << 8) | lo;
+    if (val & 0x8000) val = val - 0x10000;
+    out[i] = val / 32768;
+  }
+  return out;
+}
+
+export class AudioPlayer {
+  private ctx: AudioContext;
+  private gain: GainNode;
+  private nextTime: number;
+  private rate = 1.0;
+  private sources: AudioBufferSourceNode[] = [];
+  private fade = 0.015;
+
+  constructor() {
+    this.ctx = new AudioContext();
+    this.gain = this.ctx.createGain();
+    this.gain.connect(this.ctx.destination);
+    this.nextTime = this.ctx.currentTime;
+  }
+
+  setRate(r: number) {
+    this.rate = r;
+  }
+
+  enqueue(pcm16Base64: string, sampleRate: number) {
+    this.ctx.resume();
+    const float32 = decodePcm16(pcm16Base64);
+    const buffer = this.ctx.createBuffer(1, float32.length, sampleRate);
+    buffer.getChannelData(0).set(float32);
+
+    const source = this.ctx.createBufferSource();
+    source.buffer = buffer;
+    source.playbackRate.value = this.rate;
+
+    const gain = this.ctx.createGain();
+    const start = Math.max(this.nextTime, this.ctx.currentTime);
+    const duration = buffer.duration / this.rate;
+
+    gain.gain.setValueAtTime(0, start);
+    gain.gain.linearRampToValueAtTime(1, start + this.fade);
+    gain.gain.setValueAtTime(1, start + duration - this.fade);
+    gain.gain.linearRampToValueAtTime(0, start + duration);
+
+    source.connect(gain).connect(this.gain);
+    source.start(start);
+    this.sources.push(source);
+    this.nextTime = start + duration - this.fade;
+  }
+
+  stop() {
+    for (const s of this.sources) {
+      try { s.stop(); } catch (e) {}
+    }
+    this.sources = [];
+    this.nextTime = this.ctx.currentTime;
+  }
+}

--- a/docs/EXTENSION_MVP.md
+++ b/docs/EXTENSION_MVP.md
@@ -1,0 +1,74 @@
+# Poopify Chrome Extension MVP
+
+This document describes the structure, design decisions, and flow of the Poopify text-to-speech Chrome extension prototype that lives under `clients/extension/`.
+
+## Overview
+
+The extension provides two ways to play text using the Poopify TTS daemon:
+
+1. **Context menu** – Right–click a text selection and choose "Read selection with Poopify".
+2. **Popup UI** – Use the extension action popup to paste text, adjust playback rate/voice, and play/stop.
+
+Audio is streamed from a local FastAPI daemon (`ws://127.0.0.1:8000/api/stream`) and rendered with WebAudio in the current tab. If the daemon is unreachable the extension falls back to the browser Web Speech API.
+
+## Project Structure
+
+```
+clients/extension/
+  manifest.json       -- Manifest V3 definition
+  background.ts/js    -- Service worker orchestrating TTS sessions
+  content.ts/js       -- Content script hosting the audio player
+  popup.ts/js         -- Popup logic for pasted text playback and settings
+  popup.html          -- Popup markup
+  utils/audio.ts/js   -- Shared WebAudio utilities and AudioPlayer
+  tsconfig.json       -- Build configuration for TypeScript
+```
+
+TypeScript sources (`.ts`) are compiled to plain JavaScript (`.js`) using `tsc` without a bundler to keep the setup simple.
+
+> **Note:** Compiled `.js` files and icon assets are intentionally left out of version control. See [Local Setup](#local-setup) for instructions on generating them.
+
+## Runtime Architecture
+
+### Background Service Worker (`background.ts`)
+- Creates the context menu on installation.
+- Stores user settings (`rate`, `voice`) in `chrome.storage.sync`.
+- For playback requests it opens a WebSocket to the local TTS daemon and streams JSON messages.
+- Audio frames `{type:"audio", pcm16_base64, sample_rate}` are forwarded to the active tab's content script.
+- If the WebSocket fails or yields no audio, the worker commands the content script to use Web Speech API instead.
+- Exposes message handlers for the popup to start/stop playback and update settings.
+
+### Content Script (`content.ts`)
+- Provides the selected text to the worker when asked (`get-selection`).
+- Hosts a single `AudioContext` and an `AudioPlayer` instance for the tab.
+- Receives audio frames, decodes base64 PCM16, and schedules them sequentially with a small (~15ms) crossfade for gapless playback.
+- Can cancel playback and invoke Web Speech API for fallback speech.
+
+### Popup (`popup.ts` & `popup.html`)
+- Simple UI with textarea, play/stop buttons, rate slider (0.8–2.0×), voice dropdown, and a "Play in this tab" checkbox.
+- Reads/writes settings via `chrome.storage.sync`.
+- Sends "play-text" and "stop" messages to the background worker.
+
+### Audio Utilities (`utils/audio.ts`)
+- `decodePcm16` converts base64-encoded 16‑bit PCM to `Float32Array` for WebAudio.
+- `AudioPlayer` schedules buffers on an `AudioContext`, applying playback rate and a short gain ramp for crossfading.
+
+## Design Decisions
+
+- **Content script playback** – Audio is rendered inside the active tab rather than an offscreen document to minimize complexity and latency.
+- **WebSocket streaming** – The extension streams sentence-level PCM16 chunks from the daemon to start playback as soon as possible.
+- **Crossfaded scheduling** – Each chunk is scheduled with a 15 ms fade in/out to avoid clicks and gaps.
+- **Fallback to Web Speech API** – If the daemon is offline or unreachable, the extension remains usable via built-in speech synthesis.
+- **Lightweight tooling** – The extension uses plain TypeScript with `tsc` compilation; no bundler or framework is required for this MVP.
+
+## Limitations & Future Work
+
+- No word highlighting or timing information is handled yet.
+- Playback rate changes apply only to future audio buffers (no time‑stretching of already scheduled audio).
+- Additional controls (voices, settings UI) are minimal and intended for expansion in future iterations.
+ 
+## Local Setup
+
+1. **Generate JavaScript:** Run `npx tsc -p clients/extension/tsconfig.json` to compile the TypeScript sources in-place, producing `background.js`, `content.js`, `popup.js`, and utility scripts required by Chrome.
+2. **Provide Icons:** Add 16×16, 48×48, and 128×128 PNG images at `clients/extension/icons/icon16.png`, `icon48.png`, and `icon128.png`. These are referenced by `manifest.json` but not tracked in the repository.
+3. **Load the extension:** Use Chrome's **Load unpacked** feature to point at `clients/extension/` after generating scripts and icons.


### PR DESCRIPTION
## Summary
- add Manifest V3 Chrome extension scaffold for Poopify TTS
- stream audio from local daemon with WebAudio playback and crossfade
- fallback to Web Speech API when daemon unavailable
- drop generated JS and icon assets from version control and document how to provide them locally

## Testing
- `npx tsc -p clients/extension/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689c1b51b3388332878c7506afb0d93d